### PR TITLE
Fix lexgui import and specify fixed version

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,13 +4,13 @@
     <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>wgpuEngine Docs</title>
-    <link rel="stylesheet" href="https://cdn.skypack.dev/lexgui/build/lexgui.css">
-    <link rel="stylesheet" href="https://cdn.skypack.dev/lexgui/build/lexgui-docs.css">
+    <link rel="stylesheet" href="https://cdn.skypack.dev/lexgui@^0.7.10/build/lexgui.css">
+    <link rel="stylesheet" href="https://cdn.skypack.dev/lexgui@^0.7.10/build/lexgui-docs.css">
     <script type="importmap">
         {
           "imports": {
-            "lexgui": "https://cdn.skypack.dev/lexgui/build/lexgui.module.js",
-            "lexgui/components/": "https://cdn.skypack.dev/lexgui/build/components/"
+            "lexgui": "https://cdn.skypack.dev/lexgui@^0.7.10/build/lexgui.module.js",
+            "lexgui/extensions/": "https://cdn.skypack.dev/lexgui@^0.7.10/build/extensions/"
           }
         }
     </script>
@@ -20,7 +20,7 @@
     <script type="module">
 
         import { LX } from 'lexgui';
-        import 'lexgui/components/docmaker.js';
+        import 'lexgui/extensions/docmaker.js';
 
         window.LX = LX;
 


### PR DESCRIPTION
It looks like the lexgui import changed from components to extensions, I also imported a fixed version so that new lexgui updates with api changes are not automatically breaking the docs again.