### PR TITLE
macOS: skip loginctl X11/Wayland probe (UNIX is also true on Apple)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,8 +278,16 @@ endif()
 set(WGPU_USE_X11 OFF)
 set(WGPU_USE_WAYLAND OFF)
 
-# Check if display server is x11 or wayland
-if (UNIX)
+# Check if display server is x11 or wayland.
+# Gated on "NOT APPLE" because in CMake, APPLE is a subset of UNIX, but macOS
+# uses Metal (or Vulkan via MoltenVK) — never X11/Wayland. Without this guard,
+# `loginctl` is missing on macOS so the wayland probe returns empty, the
+# `else ()` branch fires, and WGPU_USE_X11 is set TRUE. That then propagates
+# into libraries/webgpu/cmake/FetchDawn.cmake which LOCAL-sets DAWN_USE_X11=ON,
+# overriding any cache-level setting. Downstream Dawn sources (e.g.
+# native/vulkan/Instance.cpp) then include X11Functions.h whose
+# xlib_with_undefs.h `#error`s on non-Linux, breaking the build.
+if (UNIX AND NOT APPLE)
 	execute_process(
 		COMMAND bash -c [=[loginctl show-session $(loginctl user-status $USER | grep -E -m 1 'session-[0-9]+\.scope' | sed -E 's/^.*?session-([0-9]+)\.scope.*$/\1/') -p Type | grep -ic wayland]=]
 		OUTPUT_VARIABLE is_wayland


### PR DESCRIPTION
## Summary

Gates the `loginctl`-driven X11/Wayland detection at the top of `CMakeLists.txt` on `UNIX AND NOT APPLE` instead of bare `UNIX`. One-line fix that unblocks building wgpuEngine on macOS.

## Why

In CMake, `APPLE` is a subset of `UNIX`. The current block:

```cmake
if (UNIX)
    execute_process(COMMAND bash -c [=[loginctl show-session ...]=]
                    OUTPUT_VARIABLE is_wayland)
    if (\"\${is_wayland}\" EQUAL \"1\")
        set(WGPU_USE_WAYLAND TRUE)
    else ()
        set(WGPU_USE_X11 TRUE)
    endif()
endif()
```

…fires on macOS too. `loginctl` doesn't exist there, so the wayland probe returns empty, the \`else ()\` branch fires, and \`WGPU_USE_X11\` gets set \`TRUE\`. That then LOCAL-sets \`DAWN_USE_X11=ON\` inside \`libraries/webgpu/cmake/FetchDawn.cmake\` (overriding any cache-level \`-DDAWN_USE_X11:BOOL=OFF\`). Dawn then compiles sources that \`#include X11Functions.h\` whose \`xlib_with_undefs.h\` \`#error\`s on non-Linux, and the build fails.

Adding \`AND NOT APPLE\` to the guard is enough: macOS uses Metal (or Vulkan via MoltenVK) and never benefits from the X11/Wayland selection.

## Test plan

- [x] Builds on Apple Silicon (M1, macOS 14, AppleClang 17, Vulkan SDK 1.4.341) when configured with \`-DDAWN_USE_X11:BOOL=OFF -DDAWN_USE_WAYLAND:BOOL=OFF\`. Without this patch the configure step writes \`WGPU_USE_X11=TRUE\` and the subsequent Dawn build hits the \`xlib_with_undefs.h\` \`#error\`.
- [x] No change in behavior on Linux (probe still runs, X11/Wayland still detected).
- [x] No change in behavior on Windows (\`UNIX\` was already false).

## Context

Discovered while building wgpuEngine on macOS for a pre-proposal feasibility spike validating Dawn-native + OpenXR (via wgpuEngine + dawnxr) as the primary delivery surface for an upcoming Navy SBIR phase-I VR application. This is one of two macOS-host build patches I'm sending upstream from that work; the other adds \`openxr_loader\` as a build target on Apple. Happy to combine them if you'd prefer a single PR.