### PR TITLE
macOS: build openxr_loader (without linking it into the engine library)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,22 @@ if (NOT EMSCRIPTEN)
         endif()
     endif()
 
+    # On Apple, build openxr_loader as a target but do NOT add it to the
+    # PROJECT_NAME link surface — wgpuEngine on Apple historically built
+    # without XR and we don't want to silently extend its link contract.
+    # The Khronos OpenXR-SDK-Source (libraries/openxr) compiles cleanly
+    # on macOS; downstream projects that want OpenXR on Apple can link
+    # the resulting openxr_loader target directly. The outer
+    # `if (NOT APPLE)` block above stays as-is because the Vulkan-Headers
+    # branch references a target that isn't fetched on Apple.
+    if (APPLE AND NOT WGPUENGINE_DISABLE_XR)
+        set(BUILD_LOADER_WITH_EXCEPTION_HANDLING OFF)
+        add_subdirectory(libraries/openxr)
+        set_property(TARGET openxr_loader PROPERTY FOLDER "External/OpenXR")
+        set_property(TARGET generate_openxr_header PROPERTY FOLDER "External/OpenXR")
+        set_property(TARGET xr_global_generated_files PROPERTY FOLDER "External/OpenXR")
+    endif()
+
     # glfw
     add_subdirectory(libraries/glfw)
     target_link_libraries(${PROJECT_NAME} PUBLIC glfw)


### PR DESCRIPTION
## Summary

Adds a parallel `if (APPLE AND NOT WGPUENGINE_DISABLE_XR)` block that runs `add_subdirectory(libraries/openxr)` on Apple, so `openxr_loader` becomes a buildable target. Crucially does **not** call `target_link_libraries(\${PROJECT_NAME} PUBLIC openxr_loader)` on Apple — existing macOS users of wgpuEngine have a link surface that doesn't include openxr_loader, and silently extending it could break their builds.

## Why

The current top-of-section guard:

```cmake
if (NOT APPLE)
    if(NOT WGPUENGINE_FORCE_DX12)
        # Vulkan-Headers (depends on target that isn't fetched on Apple)
    endif()
    if(NOT WGPUENGINE_DISABLE_XR)
        # openxr (no Apple dependency)
    endif()
endif()
```

…gates both clauses together. The Vulkan-Headers gating is justified — that target isn't fetched on Apple. But the openxr_loader half is gated unnecessarily: the Khronos OpenXR-SDK-Source in `libraries/openxr/` compiles cleanly on macOS as a first-class target (the SDK's own CMake treats Apple as a supported platform).

Use case: macOS-host inner-loop development for native-OpenXR XR engines targeting Quest 3 / Snapdragon XR2. Together with the companion `__APPLE__` arm patch I'm submitting to `upf-gti/dawnxr`, this enables a complete OpenXR stereo render path against the Meta XR Simulator (Apple Silicon native build) from the same source tree that cross-compiles to Android NDK arm64 for the device target.

## Test plan

- [x] On Apple Silicon (M1, macOS 14, AppleClang 17), `ninja openxr_loader` in the wgpuEngine build dir now produces `libraries/openxr/src/loader/libopenxr_loader.dylib` (~580 KB).
- [x] End-to-end stereo XR render against Meta XR Simulator 71.0.0 works: 276 frames in 5s at 1680×1760 per eye (Quest 3 native projection resolution).
- [x] No change in link surface of the `wgpuEngine` library target on Apple (the `target_link_libraries` line is intentionally omitted in the Apple block).
- [x] No change on Linux, Windows, or Emscripten — the existing `if (NOT APPLE)` block is untouched.

## Companion PRs

- [PR #X] dawnxr: add `__APPLE__` arm to dawnxr.h (`upf-gti/dawnxr#1`)
- [PR #X] wgpuEngine: skip loginctl X11/Wayland probe on Apple (`upf-gti/wgpuEngine#11`)

Happy to combine this with the X11/Wayland PR into a single "macOS-host inner loop" patch if you'd prefer a single review — the two are independent fixes so I split them, but they share context.