### PR TITLE
Added alpha opque into shader

### DIFF
--- a/data/shaders/mesh_forward.wgsl
+++ b/data/shaders/mesh_forward.wgsl
@@ -257,7 +257,11 @@ fn fs_main(in: VertexOutput, @builtin(front_facing) is_front_facing: bool) -> Fr
         final_color = pow(final_color, vec3(1.0 / 2.2));
     }
 
+#ifdef ALPHA_OPAQUE
+    out.color = vec4f(final_color, 1.0);
+#else
     out.color = vec4f(final_color, alpha);
+#endif
 
     return out;
 }


### PR DESCRIPTION
We were looking at the engine with Juan in the mesh_forward.wgsl. Alpha_opaque is listed as a material transparency type but then not supported in the shader. 